### PR TITLE
Upgrade opentracing-api to 0.31.0

### DIFF
--- a/httpasyncclient/src/main/java/io/opentracing/contrib/httpcomponents/SpanHttpAsync.java
+++ b/httpasyncclient/src/main/java/io/opentracing/contrib/httpcomponents/SpanHttpAsync.java
@@ -2,7 +2,7 @@ package io.opentracing.contrib.httpcomponents;
 
 import com.github.threadcontext.Context;
 import com.github.threadcontext.httpasyncclient.ContextAsyncClient;
-import io.opentracing.contrib.global.GlobalTracer;
+import io.opentracing.util.GlobalTracer;
 import io.opentracing.threadcontext.ContextSpan;
 import java.util.Arrays;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;

--- a/httpclient/build.sbt
+++ b/httpclient/build.sbt
@@ -1,7 +1,7 @@
 libraryDependencies ++= Seq(
   "com.lucidchart" % "opentracing-thread-context" % "0.4",
-  "io.opentracing" % "opentracing-api" % "0.20.7",
-  "io.opentracing.contrib" % "opentracing-globaltracer" % "0.1.0",
+  "io.opentracing" % "opentracing-api" % "0.31.0",
+  "io.opentracing" % "opentracing-util" % "0.31.0",
   "org.apache.httpcomponents" % "httpclient" % "4.5.2"
 )
 

--- a/httpclient/src/main/java/io/opentracing/contrib/httpcomponents/SpanHttpClientBuilder.java
+++ b/httpclient/src/main/java/io/opentracing/contrib/httpcomponents/SpanHttpClientBuilder.java
@@ -1,7 +1,7 @@
 package io.opentracing.contrib.httpcomponents;
 
 import io.opentracing.Tracer;
-import io.opentracing.contrib.global.GlobalTracer;
+import io.opentracing.util.GlobalTracer;
 import io.opentracing.threadcontext.ContextSpan;
 import java.util.ArrayList;
 import java.util.List;

--- a/httpclient/src/main/java/io/opentracing/contrib/httpcomponents/StandardHttpTagger.java
+++ b/httpclient/src/main/java/io/opentracing/contrib/httpcomponents/StandardHttpTagger.java
@@ -33,11 +33,11 @@ public class StandardHttpTagger implements HttpTagger {
         Tags.PEER_HOSTNAME.set(span, peer.getHostName());
         int port = peer.getPort();
         if (port >= 0) {
-            Tags.PEER_PORT.set(span, (short)port);
+            Tags.PEER_PORT.set(span, port);
         } else if (peer.getSchemeName().equals("http")) {
-            Tags.PEER_PORT.set(span, (short)80);
+            Tags.PEER_PORT.set(span, 80);
         } else {
-            Tags.PEER_PORT.set(span, (short)443);
+            Tags.PEER_PORT.set(span, 443);
         }
     }
 

--- a/httpcore/build.sbt
+++ b/httpcore/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
-  "io.opentracing" % "opentracing-api" % "0.20.7",
+  "io.opentracing" % "opentracing-api" % "0.31.0",
   "org.apache.httpcomponents" % "httpcore" % "4.4.5"
 )
 


### PR DESCRIPTION
This one required a few more changes than the other PRs. 

-The `GlobalTracer` has been moved from `io.opentracing.contrib.global` to `io.opentracing.util`, which had to be reflected in both the build file and in the import statements. 
-`spanBuilder.start()` no longer requires a call to `close()` at the end of its usage, so the try/finally block needed to be removed.
-The `port.set()` function now takes an integer, rather than a short, so conversions to short needed to be removed.